### PR TITLE
player.getName() NPE Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.8.7-R0.1-SNAPSHOT</version>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <!--Bukkit API-->
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.8.7-R0.1-SNAPSHOT</version>
+            <version>1.8.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/supersourmonkey/novabungeeannouncer/PlayerMessage.java
+++ b/src/main/java/com/supersourmonkey/novabungeeannouncer/PlayerMessage.java
@@ -2,6 +2,7 @@ package com.supersourmonkey.novabungeeannouncer;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.logging.Logger;
 
 import com.supersour.json.JSONArray;
 import com.supersour.json.JSONObject;
@@ -23,8 +24,9 @@ public class PlayerMessage {
 	String permission = "";
 	String type = "";
 	checkJson json = new checkJson();
-	
-	public PlayerMessage(String msg, ProxiedPlayer pp, String perm, String type){
+    Logger logger = ProxyServer.getInstance().getLogger();
+
+    public PlayerMessage(String msg, ProxiedPlayer pp, String perm, String type){
 		message = msg;
 		player = pp;
 		permission = perm;
@@ -186,8 +188,32 @@ public class PlayerMessage {
 	}
 	
 	public String replaceValues(String input){
-		input = input.replaceAll("%playername%", player.getName());
-		return input;
+        try {
+            input = input.replaceAll("%playername%", player.getName());
+            return input;
+
+        }
+        catch (NullPointerException npe) {
+            logger.severe("Failed to get a player's name!");
+            try {
+                if (player != null) {
+                    boolean foundPlayer = false;
+                    for(ProxiedPlayer pp : ProxyServer.getInstance().getPlayers()) {
+                        if (player.equals(pp)) {
+                            foundPlayer = true;
+                            logger.info("[Debug] Player found.");
+                        }
+                    }
+                    if (!foundPlayer) {
+                        logger.info("[DEBUG] Couldn't located the player passed");
+                    }
+                }
+            }
+            catch (Exception ex) {
+                logger.severe("Looks like a server might be down!");
+            }
+        }
+        return "player";
 	}
 	
 	public static void sendEvent(String eventName, String arg){


### PR DESCRIPTION
In some cases it seems that the passed ProxiedPlayer is a null instance. As such, when replacing %playername% with the player's name will not send any message to that player if it happens and also print a nasty stack trace.

As such if it is null this will no gracefully fail and use "player" instead of not sending anything at all.
